### PR TITLE
[FEAT-80] Add `database` prop to QueryData VO

### DIFF
--- a/src/ValueObjects/Data/QueryData.php
+++ b/src/ValueObjects/Data/QueryData.php
@@ -10,6 +10,7 @@ class QueryData implements Arrayable
 {
     public function __construct(
         public readonly string $sql,
+        public readonly string $database,
         public readonly array $bindings,
         public readonly float $time,
         public readonly string $connectionName,
@@ -21,6 +22,7 @@ class QueryData implements Arrayable
     {
         return new self(
             sql: QueryData::formatBindingsInSQL($e->sql, $e->bindings),
+            database: $e->connection->getDatabaseName(),
             bindings: $e->bindings,
             time: $e->time,
             connectionName: $e->connectionName,
@@ -52,6 +54,7 @@ class QueryData implements Arrayable
     {
         return [
             'sql' => $this->sql,
+            'database' => $this->database,
             'bindings' => $this->bindings,
             'time' => $this->time,
             'connection_name' => $this->connectionName,
@@ -63,6 +66,7 @@ class QueryData implements Arrayable
     {
         return new QueryData(
             sql: $args['sql'],
+            database: $args['database'],
             bindings: $args['bindings'],
             time: $args['time'],
             connectionName: $args['connection_name'],
@@ -74,6 +78,7 @@ class QueryData implements Arrayable
     {
         return [
             'sql' => $this->sql,
+            'database' => $this->database,
             'bindings' => json_encode($this->bindings),
             'time' => $this->time,
             'connection_name' => $this->connectionName,

--- a/tests/Unit/ValueObjects/ExceptionDataTest.php
+++ b/tests/Unit/ValueObjects/ExceptionDataTest.php
@@ -18,9 +18,9 @@ class ExceptionDataTest extends TestCase
         $this->assertIsArray($exceptionData);
         $this->assertNotEmpty($exceptionData);
 
-        $this->assertIsString($exceptionData['message'], 'test exception');
-        $this->assertIsString($exceptionData['kind'], 'Exception');
-        $this->assertIsString($exceptionData['file'], __FILE__);
+        $this->assertEquals($exceptionData['message'], 'test exception');
+        $this->assertEquals($exceptionData['kind'], 'Exception');
+        $this->assertEquals($exceptionData['file'], __FILE__);
         $this->assertIsString($exceptionData['trace']);
         $this->assertIsInt($exceptionData['line'], 15);
         $this->assertIsString($exceptionData['request']);

--- a/tests/Unit/ValueObjects/QueryDataTest.php
+++ b/tests/Unit/ValueObjects/QueryDataTest.php
@@ -34,10 +34,11 @@ class QueryDataTest extends TestCase
         $this->assertIsArray($queryData);
         $this->assertNotEmpty($queryData);
 
-        $this->assertIsString($queryData['sql'], 'test query');
+        $this->assertEquals($queryData['sql'], 'test Query');
+        $this->assertEquals($queryData['database'], 'test_database');
         $this->assertIsString($queryData['bindings']);
-        $this->assertIsFloat($queryData['time'], 2.98);
-        $this->assertIsString($queryData['connection_name'], 'test connection');
+        $this->assertEquals($queryData['time'], 2.98);
+        $this->assertEquals($queryData['connection_name'], 'default');
         $this->assertIsString($queryData['queried_at']);
     }
 
@@ -65,10 +66,11 @@ class QueryDataTest extends TestCase
         $this->assertIsArray($array);
         $this->assertNotEmpty($array);
 
-        $this->assertIsString($array['sql'], 'test query');
+        $this->assertEquals($array['sql'], 'test Query');
+        $this->assertEquals($array['database'], 'test_database');
         $this->assertIsArray($array['bindings']);
         $this->assertIsFloat($array['time'], 2.98);
-        $this->assertIsString($array['connection_name'], 'test connection');
+        $this->assertEquals($array['connection_name'], 'default');
         $this->assertIsObject($array['queried_at']);
         $this->assertInstanceOf(Carbon::class, $array['queried_at']);
     }

--- a/tests/Unit/ValueObjects/RequestDataTest.php
+++ b/tests/Unit/ValueObjects/RequestDataTest.php
@@ -17,16 +17,16 @@ class RequestDataTest extends TestCase
         $this->assertIsArray($request);
         $this->assertNotEmpty($request);
 
-        $this->assertIsString($request['attributes'], '[]');
-        $this->assertIsString($request['body'], '""');
-        $this->assertIsString($request['files'], '[]');
+        $this->assertEquals($request['attributes'], '[]');
+        $this->assertEquals($request['body'], '""');
+        $this->assertEquals($request['files'], '[]');
 
         $headers = json_decode($request['headers']);
         $this->assertIsObject($headers);
         $this->assertNotEmpty($headers);
-        $this->assertIsString($headers->host[0], 'localhost');
+        $this->assertEquals($headers->host[0], 'localhost');
 
-        $this->assertIsString($request['content'], '');
+        $this->assertEquals($request['content'], '');
 
         $server = json_decode($request['server']);
         $this->assertIsObject($server);
@@ -34,23 +34,23 @@ class RequestDataTest extends TestCase
 
         $uri = json_decode($request['uri']);
 
-        $this->assertIsString($uri->root, 'http://localhost');
-        $this->assertIsString($uri->path, '/');
-        $this->assertIsString($uri->host, 'localhost');
+        $this->assertEquals($uri->root, 'http://localhost');
+        $this->assertEquals($uri->path, '/');
+        $this->assertEquals($uri->host, 'localhost');
         $this->assertIsNumeric($uri->port, '80');
 
-        $this->assertIsString($request['method'], 'GET');
-        $this->assertIsString($request['session'], '[]');
-        $this->assertIsString($request['format'], 'html');
-        $this->assertIsString($request['locale'], 'en');
+        $this->assertEquals($request['method'], 'GET');
+        $this->assertEquals($request['session'], '[]');
+        $this->assertEquals($request['format'], 'html');
+        $this->assertEquals($request['locale'], 'en');
 
         $response = json_decode($request['response']);
         $this->assertIsObject($response);
         $this->assertIsNumeric($response->status, 200);
-        $this->assertIsString($response->status_text, 'OK');
+        $this->assertEquals($response->status_text, 'OK');
         $this->assertIsObject($response->headers);
-        $this->assertIsString($response->content, 'HTML Response');
-        $this->assertIsString($response->version, '1.0');
+        $this->assertEquals($response->content, 'HTML Response');
+        $this->assertEquals($response->version, '1.0');
     }
 
     /** @test */
@@ -68,29 +68,29 @@ class RequestDataTest extends TestCase
 
         $this->assertIsArray($request['headers']);
         $this->assertNotEmpty($request['headers']);
-        $this->assertIsString($request['headers']['host'][0], 'localhost');
+        $this->assertEquals($request['headers']['host'][0], 'localhost');
 
-        $this->assertIsString($request['content'], '');
+        $this->assertEquals($request['content'], '');
 
         $this->assertIsArray($request['server']);
         $this->assertNotEmpty($request['server']);
 
-        $this->assertIsString($request['uri']['root'], 'http://localhost');
-        $this->assertIsString($request['uri']['path'], '/');
-        $this->assertIsString($request['uri']['host'], 'localhost');
+        $this->assertEquals($request['uri']['root'], 'http://localhost');
+        $this->assertEquals($request['uri']['path'], '/');
+        $this->assertEquals($request['uri']['host'], 'localhost');
         $this->assertIsNumeric($request['uri']['port'], '80');
 
-        $this->assertIsString($request['method'], 'GET');
+        $this->assertEquals($request['method'], 'GET');
         $this->assertEquals($request['session'], []);
-        $this->assertIsString($request['format'], 'html');
-        $this->assertIsString($request['locale'], 'en');
+        $this->assertEquals($request['format'], 'html');
+        $this->assertEquals($request['locale'], 'en');
 
         $this->assertIsArray($request['response']);
         $this->assertNotEmpty($request['response']);
         $this->assertIsNumeric($request['response']['status'], 200);
-        $this->assertIsString($request['response']['status_text'], 'OK');
+        $this->assertEquals($request['response']['status_text'], 'OK');
         $this->assertIsArray($request['response']['headers']);
-        $this->assertIsString($request['response']['content'], 'HTML Response');
-        $this->assertIsString($request['response']['version'], '1.0');
+        $this->assertEquals($request['response']['content'], 'HTML Response');
+        $this->assertEquals($request['response']['version'], '1.0');
     }
 }

--- a/tests/Unit/ValueObjects/ResponseDataTest.php
+++ b/tests/Unit/ValueObjects/ResponseDataTest.php
@@ -13,15 +13,15 @@ class ResponseDataTest extends TestCase
     {
         $response = ResponseData::from(new Response())->debugFormat();
 
-        $this->assertIsString($response['status'], '200');
-        $this->assertIsString($response['status_text'], 'OK');
+        $this->assertEquals($response['status'], '200');
+        $this->assertEquals($response['status_text'], 'OK');
 
         $headers = json_decode($response['headers']);
         $this->assertIsObject($headers);
         $this->assertNotEmpty($headers);
 
-        $this->assertIsString($response['content'], 'HTML Response');
-        $this->assertIsString($response['version'], '1.0');
+        $this->assertEquals($response['content'], 'HTML Response');
+        $this->assertEquals($response['version'], '1.0');
     }
 
     /** @test */
@@ -30,12 +30,12 @@ class ResponseDataTest extends TestCase
         $response = ResponseData::from(new Response())->toArray();
 
         $this->assertIsNumeric($response['status'], '200');
-        $this->assertIsString($response['status_text'], 'OK');
+        $this->assertEquals($response['status_text'], 'OK');
 
         $this->assertIsArray($response['headers']);
         $this->assertNotEmpty($response['headers']);
 
-        $this->assertIsString($response['content'], 'HTML Response');
-        $this->assertIsString($response['version'], '1.0');
+        $this->assertEquals($response['content'], 'HTML Response');
+        $this->assertEquals($response['version'], '1.0');
     }
 }


### PR DESCRIPTION
Extra: Tests have been updated to use `assertEquals()` instead of `assertIsString()`.

For some awful reason we tought that the `assertIsString()` also compared the strings from the first parameter with the second parameter. Oops.